### PR TITLE
PHP E_STRICTで表示されるエラー対応

### DIFF
--- a/Model/Behavior/CsvImportBehavior.php
+++ b/Model/Behavior/CsvImportBehavior.php
@@ -16,7 +16,7 @@ class CsvImportBehavior extends ModelBehavior {
         'csv_path' => self::CSV_IMPORT_FILE_NAME
     );
 
-    function setup(&$model, $config = array()) {
+    function setup(Model $model, $config = array()) {
         $settings = array_merge($this->_defaults, $config);
         $this->settings[$model->alias] = $settings;
     }


### PR DESCRIPTION
継承によりメソッドをオーバーライドする場合は、継承元と同じメソッド定義にする。CsvImportBehavior::setup()の引数が、継承元のModelBehavior::setup()と引数が異なっていたので、エラーが出ていたので同じ引数にしておく。
